### PR TITLE
Use default RabbitMQ port (5672) instead of 5671

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ base:
         - sensu.uchiwa
 ```
 
+Backward incompatible changes
+=============================
+
+2015-04-15
+----------
+
+The default ``sensu:rabbitmq:port`` value is now 5672 (which is the default port of RabbitMQ) instead of 5671.
+
+* If you happened to have used the default previous value of 5671, you should now set it in your pillar file or change your RabbitMQ configuration.
+* If you overrode the previous default value of 5671 with 5672, you can now safely remove it.
+* If you set up something else instead, you don't have to change anything :)
+
+
 Available states
 ================
 * [sensu](#sensu)

--- a/sensu/pillar_map.jinja
+++ b/sensu/pillar_map.jinja
@@ -16,7 +16,7 @@
         },
         'rabbitmq': {
             'host': 'localhost',
-            'port': 5671,
+            'port': 5672,
             'vhost': '/sensu',
             'user': 'sensu',
             'password': ''


### PR DESCRIPTION
RabbitMQ use by default the TCP port 5672 (http://www.rabbitmq.com/configure.html), I think it makes more sense to use it, especially since the one proposed is close enough that you can mistaken it.