### PR TITLE
Fixed the gem installation to look for literal names

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -83,6 +83,6 @@ sensu-client:
 client_install_{{ gem }}:
   cmd.run:
     - name: {{ gem_path }} install {{ gem }} --no-ri --no-rdoc
-    - unless: {{ gem_path }} list | grep -q {{ gem }}
+    - unless: {{ gem_path }} list | grep -qE "^{{ gem }}\s+"
 {% endfor %}
 

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -55,7 +55,7 @@ include:
 server_install_{{ gem }}:
   cmd.run:
     - name: /opt/sensu/embedded/bin/gem install {{ gem }} --no-ri --no-rdoc
-    - unless: /opt/sensu/embedded/bin/gem list | grep -q {{ gem }}
+    - unless: /opt/sensu/embedded/bin/gem list | grep -qE "^{{ gem }}\s+"
 {% endfor %}
 
 sensu-server:


### PR DESCRIPTION
This fixes an issue where the gem list will look for redis and find another module with redis in it.