### PR TITLE
Require the repository to be configured before installing the package

### DIFF
--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -18,9 +18,9 @@ sensu:
     - baseurl: http://repos.sensuapp.org/yum/el/$releasever/$basearch/
     - gpgcheck: 0
     - enabled: 1
+    {% endif %}
     - require_in:
       - pkg: sensu
-    {% endif %}
   {% endif %}
   pkg:
     - installed


### PR DESCRIPTION
It was previously configured only for the Redhat family distributions, although it has to be for all the Linux distributions actually.