### PR TITLE
fix extraneous comma in the site name

### DIFF
--- a/sensu/uchiwa.sls
+++ b/sensu/uchiwa.sls
@@ -22,7 +22,7 @@ uchiwa:
     - dataset:
         sensu:
         {%- for site, value in sites %}
-          - name: {{ site}},
+          - name: {{ site }}
             host: {{ get(value, 'host') }}
             ssl: {{ get(value, 'ssl') }}
             port: {{ get(value, 'port') }}


### PR DESCRIPTION
There was a errant comma in the uchiwa UI for the site names. Removed it.