### PR TITLE
Separate Redis configuration from the server configuration

### DIFF
--- a/sensu/api.sls
+++ b/sensu/api.sls
@@ -2,6 +2,8 @@
 
 include:
   - sensu
+  - sensu.rabbitmq_conf
+  - sensu.redis_conf
 
 /etc/sensu/conf.d/api.json:
   file.serialize:
@@ -23,5 +25,9 @@ sensu-api:
     - enable: True
     - require:
       - file: /etc/sensu/conf.d/api.json
+      - file: /etc/sensu/conf.d/rabbitmq.json
+      - file: /etc/sensu/conf.d/redis.json
     - watch:
       - file: /etc/sensu/conf.d/api.json
+      - file: /etc/sensu/conf.d/rabbitmq.json
+      - file: /etc/sensu/conf.d/redis.json

--- a/sensu/redis_conf.sls
+++ b/sensu/redis_conf.sls
@@ -1,0 +1,16 @@
+{% from "sensu/pillar_map.jinja" import sensu with context -%}
+
+/etc/sensu/conf.d/redis.json:
+  file.serialize:
+    - formatter: json
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: sensu
+    - dataset:
+        redis:
+          host: {{ sensu.redis.host }}
+          {% if sensu.redis.password is defined and sensu.redis.password is not none %}password: {{ sensu.redis.password }}{% endif %}
+          port: {{ sensu.redis.port }}
+

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -3,20 +3,7 @@
 include:
   - sensu
   - sensu.rabbitmq_conf
-
-/etc/sensu/conf.d/redis.json:
-  file.serialize:
-    - formatter: json
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - pkg: sensu
-    - dataset:
-        redis:
-          host: {{ sensu.redis.host }}
-          {% if sensu.redis.password is defined and sensu.redis.password is not none %}password: {{ sensu.redis.password }}{% endif %}
-          port: {{ sensu.redis.port }}
+  - sensu.redis_conf
 
 /etc/sensu/conf.d:
   file.recurse:


### PR DESCRIPTION
It allows to install Sensu API and Sensu Server on different machines,
"connected" together via Redis and RabbitMQ.

As far as I understand, both the "server" and the "API server" need to access Redis and RabbitMQ, although they don't have to be both (Sensu services) on the same machine.

This PR allows to install these two services on different machines.