### PR TITLE
api: allow to configure the API endpoint, without running the API service

### DIFF
--- a/sensu/api.sls
+++ b/sensu/api.sls
@@ -1,24 +1,8 @@
-{% from "sensu/pillar_map.jinja" import sensu with context -%}
-
 include:
   - sensu
+  - sensu.api_conf
   - sensu.rabbitmq_conf
   - sensu.redis_conf
-
-/etc/sensu/conf.d/api.json:
-  file.serialize:
-    - formatter: json
-    - user: root
-    - group: root
-    - mode: 644
-    - require:
-      - pkg: sensu
-    - dataset:
-        api:
-          host: {{ sensu.api.host }}
-          password: {{ sensu.api.password }}
-          port: {{ sensu.api.port }}
-          user: {{ sensu.api.user }}
 
 sensu-api:
   service.running:

--- a/sensu/api_conf.sls
+++ b/sensu/api_conf.sls
@@ -1,0 +1,20 @@
+{% from "sensu/pillar_map.jinja" import sensu with context -%}
+
+include:
+  - sensu
+
+/etc/sensu/conf.d/api.json:
+  file.serialize:
+    - formatter: json
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: sensu
+    - dataset:
+        api:
+          host: {{ sensu.api.host }}
+          password: {{ sensu.api.password }}
+          port: {{ sensu.api.port }}
+          user: {{ sensu.api.user }}
+

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -2,6 +2,7 @@
 
 include:
   - sensu
+  - sensu.api_conf # Some handlers need to access the API server
   - sensu.rabbitmq_conf
   - sensu.redis_conf
 


### PR DESCRIPTION
Some handlers (like the HipChat handler) require access to the API server
to discover if the event is part of a stash or not
(see https://github.com/sensu-plugins/sensu-plugin/blob/master/lib/sensu-handler.rb#L96
for more information).

This commit splits the configuration part from the service part, which
allows the configuration file to be reused across states.