### PR TITLE
repos: use the new repositories

### DIFF
--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -11,11 +11,11 @@ sensu:
   pkgrepo.managed:
     - humanname: Sensu Repository
     {% if grains['os_family'] == 'Debian' %}
-    - name: deb http://repos.sensuapp.org/apt sensu main
+    - name: deb http://repositories.sensuapp.org/apt sensu main
     - file: /etc/apt/sources.list.d/sensu.list
-    - key_url: http://repos.sensuapp.org/apt/pubkey.gpg
+    - key_url: http://repositories.sensuapp.org/apt/pubkey.gpg
     {% elif grains['os_family'] == 'RedHat' %}
-    - baseurl: http://repos.sensuapp.org/yum/el/$releasever/$basearch/
+    - baseurl: http://repositories.sensuapp.org/yum/el/$releasever/$basearch/
     - gpgcheck: 0
     - enabled: 1
     {% endif %}
@@ -24,3 +24,17 @@ sensu:
   {% endif %}
   pkg:
     - installed
+
+
+{% if grains['os_family'] != 'Windows' %}
+old sensu repository:
+  pkgrepo.absent:
+    {% if grains['os_family'] == 'Debian' %}
+    - name: deb http://repos.sensuapp.org/apt sensu main
+    - keyid: 18609E3D7580C77F # key from http://repos.sensuapp.org/apt/pubkey.gpg
+    {% elif grains['os_family'] == 'RedHat' %}
+    - name: http://repos.sensuapp.org/yum/el/$releasever/$basearch/
+    {% endif %}
+    - require_in:
+      - pkg: sensu
+{% endif %}


### PR DESCRIPTION
As per https://sensuapp.org/docs/latest/install-repositories

This has been signaled on the mailing list at https://groups.google.com/forum/#!topic/sensu-users/JlJQK8nszRI

The new state also tries to remove the old repositories. I've tested it against Debian but I don't have any RedHat machines here so I'm not sure if it works OK.