### PR TITLE
Ensure that EMBEDDED_RUBY has the correct value

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -61,11 +61,16 @@ sensu-client:
     - watch:
       - file: /etc/sensu/conf.d/*
 
-{% if sensu.client.embedded_ruby and grains['os_family'] != 'Windows' %}
+{% if grains['os_family'] != 'Windows' %}
 /etc/default/sensu:
   file.replace:
+{%- if sensu.client.embedded_ruby %}
     - pattern: 'EMBEDDED_RUBY=false'
     - repl: 'EMBEDDED_RUBY=true'
+{%- else %}
+    - pattern: 'EMBEDDED_RUBY=true'
+    - repl: 'EMBEDDED_RUBY=false'
+{%- endif %}
     - watch_in:
       - service: sensu-client
 {% endif %}


### PR DESCRIPTION
If the embedded ruby property is true on the system but set to false in the pillar the formula does not correctly set it to false.