### PR TITLE
added check name to pillar example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -42,13 +42,14 @@ sensu:
     handlers: monitoring/handlers
   # Optional: Checks within Pillar
   checks:
-    handlers:
-      - pagerduty
-    command: "/etc/sensu/plugins/check-http.rb -h localhost -p 443 -s -e 30"
-    interval: 300
-    occurences: 2
-    subscribers:
-      - ssl_server
+    check_http:
+      handlers:
+        - pagerduty
+      command: "/etc/sensu/plugins/check-http.rb -h localhost -p 443 -s -e 30"
+      interval: 300
+      occurences: 2
+      subscribers:
+        - ssl_server
   # Optional: Pillarized Handler files
   handlers:
     handlers:


### PR DESCRIPTION
Noticed that there was no name for the defined check in pillar.example. Using pillar.example this way would cause a sensu-server and sensu-api to fail upon restarting.