### PR TITLE
move checks file resource to client.sls

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -99,3 +99,18 @@ install_{{ gem }}:
     - rdoc: False
     - ri: False
 {% endfor %}
+
+{%- if salt['pillar.get']('sensu:checks') %}
+
+sensu_checks_file:
+  file.serialize:
+    - name: {{ sensu.paths.checks_file }}
+    - dataset:
+        checks: {{ salt['pillar.get']('sensu:checks') }}
+    - formatter: json
+    - require:
+      - pkg: sensu
+    - watch_in:
+      - service: sensu-client
+
+{%- endif %}

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -15,21 +15,6 @@ include:
     - watch_in:
       - service: sensu-server
 
-{%- if salt['pillar.get']('sensu:checks') %}
-
-sensu_checks_file:
-  file.serialize:
-    - name: {{ sensu.paths.checks_file }}
-    - dataset:
-        checks: {{ salt['pillar.get']('sensu:checks') }}
-    - formatter: json
-    - require:
-      - pkg: sensu
-    - watch_in:
-      - service: sensu-server
-
-{%- endif %}
-
 {%- if salt['pillar.get']('sensu:handlers') %}
 
 sensu_handlers_file:


### PR DESCRIPTION
Move the checks file resource from server.sls to client.sls, so that standalone checks can be provisioned on client systems. Subscription based checks will continue to work.