### PR TITLE
Add transport configuration along with defaults

### DIFF
--- a/sensu/pillar_map.jinja
+++ b/sensu/pillar_map.jinja
@@ -1,5 +1,9 @@
 {% set sensu = salt['grains.filter_by']({
     'default': {
+        'transport': {
+            'name': 'rabbitmq',
+            'reconnect_on_error': 'true',
+        },
         'client': {
             'embedded_ruby': False,
             'nagios_plugins': False,

--- a/sensu/transport_conf.sls
+++ b/sensu/transport_conf.sls
@@ -1,0 +1,17 @@
+{% from "sensu/pillar_map.jinja" import sensu with context -%}
+
+include:
+  - sensu
+
+/etc/sensu/conf.d/transport.conf:
+  file.serialize:
+    - formatter: json
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - pkg: sensu
+    - dataset:
+        transport:
+          name: {{ sensu.transport.name }}
+          reconnect_on_error: {{ sensu.transport.reconnect_on_error }}


### PR DESCRIPTION
I'm not sure if this was the case the last time a commit was made.. but Sensu now seems to require a transport (redis or rabbitmq) to function correctly. I believe this is relatively new, as it previously only supported rabbitmq for transport. This PR fixes that, allowing a pillar such as:

```
sensu:
  transport:
    name: rabbitmq
    reconnect_on_error: true
```
