### PR TITLE
Add ability to install Sensu from mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ Backward incompatible changes
 
 Adds the Sensu repository, and installs the Sensu package.
 
+Allows the configuration of alternative repositories (i.e. mirrors) using the following syntax:
+```
+## for ubuntu
+sensu:
+  lookup:
+    repos:
+      name: deb http://mysensumirror.org/apt/sensu sensu main
+      key_url: http://mysensumirror.org/apt/sensu/key.gpg
+
+## or for RedHat
+sensu:
+  lookup:
+    repos:
+      baseurl: http://mysensumirror.org/yum/el/$releasever/$basearch/
+
+## or if you don't want the formula to handle the repo for you...
+sensu:
+  lookup:
+    repos:
+      enabled: False
+```
+
+
 ``sensu.server``
 ------------
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ Configures sensu-client and starts the service.
 
 Check scripts can be deployed to all clients by placing them into ./sensu/files/plugins.
 
-You can use the embedded ruby or installing nagios plugins by setting:
+You can use the embedded ruby, set a proxy or mirror for installing gems, or install nagios plugins by setting:
 ```
 sensu:
   client:
     embedded_ruby: true
     nagios_plugins: true
+    gem_source: http://gemmirror.example.com:9292
+    # or
+    gem_proxy: http://squid.example.com:3128
 ```
 
 To subscribe your clients to the appropriate checks, you can update the `sensu` pillar with the required subscriptions.  You can also override the client address to another interface or change the name of the client.  In addition, you can also enable Sensu's safe mode (highly recommended, off by default).

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 sensu:
+  lookup:
+    repos:
+      name: deb http://repositories.sensuapp.org/apt sensu main
+      key_url: http://repositories.sensuapp.org/apt/pubkey.gpg
   server:
     install_gems:
       - mail

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -113,6 +113,8 @@ install_{{ gem_name }}:
     {% endif %}
     - rdoc: False
     - ri: False
+    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy', None) }}
+    - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
 {% endfor %}
 
 {%- if salt['pillar.get']('sensu:checks') %}

--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -1,3 +1,5 @@
+{% from "sensu/repos_map.jinja" import repos with context -%}
+
 {% if grains['os_family'] == 'Debian' %}
 python-apt:
   pkg:
@@ -7,16 +9,18 @@ python-apt:
 {% endif %}
 
 sensu:
-  {% if grains['os_family'] != 'Windows' %}
+  {% if repos.get('enabled') %}
   pkgrepo.managed:
     - humanname: Sensu Repository
     {% if grains['os_family'] == 'Debian' %}
-    - name: deb http://repositories.sensuapp.org/apt sensu main
+    - name: {{ repos.get('name') }}
     - file: /etc/apt/sources.list.d/sensu.list
-    - key_url: http://repositories.sensuapp.org/apt/pubkey.gpg
-    {% elif grains['os_family'] == 'RedHat' %}
-    - baseurl: http://repositories.sensuapp.org/yum/el/$releasever/$basearch/
-    - gpgcheck: 0
+    {%- if repos.get('key_url') %}
+    - key_url: {{ repos.get('key_url') }}
+    {%- endif %}
+    {%- elif grains['os_family'] == 'RedHat' %}
+    - baseurl: {{ repos.get('baseurl') }}
+    - gpgcheck: {{ repos.get('gpgcheck') }}
     - enabled: 1
     {% endif %}
     - require_in:

--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -1,0 +1,15 @@
+{% set repos = salt['grains.filter_by']({
+    'Debian': {
+        'enabled': True,
+        'name': 'deb http://repositories.sensuapp.org/apt sensu main',
+        'key_url': 'http://repositories.sensuapp.org/apt/pubkey.gpg',
+    },
+    'RedHat': {
+        'enabled': True,
+        'baseurl': 'http://repositories.sensuapp.org/yum/el/$releasever/$basearch/',
+        'gpgcheck': '0',
+    },
+    'Windows': {
+        'enabled': False,
+    }
+}, merge=salt['pillar.get']('sensu:lookup:repos'), default='Debian') %}

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -37,7 +37,7 @@ sensu_handlers_file:
       - pkg: sensu
     - watch_in:
       - service: sensu-server
-   
+
 /etc/sensu/mutators:
   file.recurse:
     - source: salt://{{ sensu.paths.mutators }}
@@ -78,6 +78,8 @@ install_{{ gem_name }}:
     {% endif %}
     - rdoc: False
     - ri: False
+    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy', None) }}
+    - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
 {% endfor %}
 
 sensu-server:


### PR DESCRIPTION
Add ability to install Sensu package via apt / yum mirror by overriding the repository that the formula configures.
Add ability to install gems using a proxy server or gem mirror.

Re: `server.sls`, I'm not 100% happy that the config comes from `sensu:client`, but followed the lead of `sensu.client.embedded_ruby`.