### PR TITLE
CentOS Linux release 7.2.1511 (Core) no fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A saltstack formula to install and configure the open source monitoring framewor
 >Note:
 See the full [Salt Formulas installation and usage instructions](http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html). This formula only manages Sensu. You are responsible for installing/configuring RabbitMQ and Redis as appropriate.
 
-Sensu can be configured/scaled with the individual states installed on multiple servers. All states are configured via the pillar file. Sane defaults are set in pillar_map.jinja and can be over-written in the pillar. The `sensu.client` state currently supports Ubuntu, CentOS and Windows. The `sensu.server`, `sensu.api` and `sensu.uchiwa` states currently support Ubuntu and CentOS. 
+Sensu can be configured/scaled with the individual states installed on multiple servers. All states are configured via the pillar file. Sane defaults are set in pillar_map.jinja and can be over-written in the pillar. The `sensu.client` state currently supports Ubuntu, CentOS and Windows. The `sensu.server`, `sensu.api` and `sensu.uchiwa` states currently support Ubuntu and CentOS.
 
 Thank you to the SaltStack community for the continued improvement of this formula!
 
@@ -124,6 +124,17 @@ sensu:
         warning: 97
         critical: 99
 ```
+
+If you would like to use the [redact](https://sensuapp.org/docs/latest/clients) feature in your checks you can add a section under client as shown here:
+
+```
+sensu:
+  client:
+    redact:
+      - password
+```
+
+This will redact any command token value who's key is defined as "password" from check configurations and logs. Command token substitution should be used in check configurations when redacting sensitive information such as passwords.
 
 If you are adding plugins/checks which have additional gem dependencies. You can add them to the pillar data and they will be installed on your Sensu clients.
 ```

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,8 @@ sensu:
     install_gems:
       - mail
       - timeout
+      - name: aws-sdk
+        version: 2.2.6
   client:
     embedded_ruby: true
     nagios_plugins: true

--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,8 @@ sensu:
   client:
     embedded_ruby: true
     nagios_plugins: true
+    # environment is required by sensu
+    environment: production
     redact:
       - password
   rabbitmq:

--- a/pillar.example
+++ b/pillar.example
@@ -6,6 +6,8 @@ sensu:
   client:
     embedded_ruby: true
     nagios_plugins: true
+    redact:
+      - password
   rabbitmq:
     host: 10.0.0.1
     user: sensu

--- a/sensu/api_conf.sls
+++ b/sensu/api_conf.sls
@@ -14,7 +14,5 @@ include:
     - dataset:
         api:
           host: {{ sensu.api.host }}
-          password: {{ sensu.api.password }}
           port: {{ sensu.api.port }}
-          user: {{ sensu.api.user }}
 

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -36,12 +36,16 @@ sensu_enable_windows_service:
           address: {{ sensu.client.address }}
           subscriptions: {{ sensu.client.subscriptions }}
           safe_mode: {{ sensu.client.safe_mode }}
+<<<<<<< HEAD
 {% if sensu.client.get("command_tokens") %}
           command_tokens: {{ sensu.client.command_tokens }}
 {% endif %}
 {% if sensu.client.get("redact") %}
           redact: {{ sensu.client.redact }}
 {% endif %}
+=======
+          keepalive: {{ sensu.client.keepalive }}
+>>>>>>> 3e357cda916c4c084e832efa3c51cb1b09ca36aa
     - require:
       - pkg: sensu
 
@@ -91,17 +95,26 @@ sensu-client:
 
 {% set gem_list = salt['pillar.get']('sensu:client:install_gems', []) %}
 {% for gem in gem_list %}
-install_{{ gem }}:
+{% if gem is mapping %}
+{% set gem_name = gem.name %}
+{% else %}
+{% set gem_name = gem %}
+{% endif %}
+install_{{ gem_name }}:
   gem.installed:
-    - name: {{ gem }}
+    - name: {{ gem_name }}
     {% if sensu.client.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
     {% else %}
     - gem_bin: None
     {% endif %}
+    {% if gem.version is defined %}
+    - version: {{ gem.version }}
+    {% endif %}
     - rdoc: False
     - ri: False
 {% endfor %}
+<<<<<<< HEAD
 
 {%- if salt['pillar.get']('sensu:checks') %}
 
@@ -117,3 +130,5 @@ sensu_checks_file:
       - service: sensu-client
 
 {%- endif %}
+=======
+>>>>>>> 3e357cda916c4c084e832efa3c51cb1b09ca36aa

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -21,6 +21,7 @@ sensu_enable_windows_service:
     - name: 'sc create sensu-client start= delayed-auto binPath= c:\opt\sensu\bin\sensu-client.exe DisplayName= "Sensu Client"'
     - unless: 'sc query sensu-client'
 {% endif %}
+
 /etc/sensu/conf.d/client.json:
   file.serialize:
     - formatter: json
@@ -36,16 +37,15 @@ sensu_enable_windows_service:
           address: {{ sensu.client.address }}
           subscriptions: {{ sensu.client.subscriptions }}
           safe_mode: {{ sensu.client.safe_mode }}
-<<<<<<< HEAD
-{% if sensu.client.get("command_tokens") %}
-          command_tokens: {{ sensu.client.command_tokens }}
-{% endif %}
-{% if sensu.client.get("redact") %}
-          redact: {{ sensu.client.redact }}
-{% endif %}
-=======
+          {% if sensu.client.get('keepalive') %}
           keepalive: {{ sensu.client.keepalive }}
->>>>>>> 3e357cda916c4c084e832efa3c51cb1b09ca36aa
+          {% endif %}
+          {% if sensu.client.get("command_tokens") %}
+          command_tokens: {{ sensu.client.command_tokens }}
+          {% endif %}
+          {% if sensu.client.get("redact") %}
+          redact: {{ sensu.client.redact }}
+          {% endif %}
     - require:
       - pkg: sensu
 
@@ -114,7 +114,6 @@ install_{{ gem_name }}:
     - rdoc: False
     - ri: False
 {% endfor %}
-<<<<<<< HEAD
 
 {%- if salt['pillar.get']('sensu:checks') %}
 
@@ -130,5 +129,3 @@ sensu_checks_file:
       - service: sensu-client
 
 {%- endif %}
-=======
->>>>>>> 3e357cda916c4c084e832efa3c51cb1b09ca36aa

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -99,3 +99,18 @@ install_{{ gem }}:
     - rdoc: False
     - ri: False
 {% endfor %}
+
+{%- if salt['pillar.get']('sensu:checks') %}
+
+sensu_checks_file:
+  file.serialize:
+    - name: {{ sensu.paths.checks_file }}
+    - dataset:
+        checks: {{ salt['pillar.get']('sensu:checks') }}
+    - formatter: json
+    - require:
+      - pkg: sensu
+    - watch_in:
+      - service: sensu-client
+
+{%- endif %}

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -39,6 +39,9 @@ sensu_enable_windows_service:
 {% if sensu.client.get("command_tokens") %}
           command_tokens: {{ sensu.client.command_tokens }}
 {% endif %}
+{% if sensu.client.get("redact") %}
+          redact: {{ sensu.client.redact }}
+{% endif %}
     - require:
       - pkg: sensu
 

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -46,6 +46,9 @@ sensu_enable_windows_service:
           {% if sensu.client.get("redact") %}
           redact: {{ sensu.client.redact }}
           {% endif %}
+          {% if sensu.client.get("environment") %}
+          environment: {{ sensu.client.environment }}
+          {% endif %}
     - require:
       - pkg: sensu
 

--- a/sensu/pillar_map.jinja
+++ b/sensu/pillar_map.jinja
@@ -3,7 +3,7 @@
         'client': {
             'embedded_ruby': False,
             'nagios_plugins': False,
-            'name': salt['grains.get']('fqdn'),
+            'name': salt['grains.get']('id'),
             'address': salt['grains.get']('ipv4')[0],
             'subscriptions': ['all'],
             'safe_mode': False

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -15,21 +15,6 @@ include:
     - watch_in:
       - service: sensu-server
 
-{%- if salt['pillar.get']('sensu:checks') %}
-
-sensu_checks_file:
-  file.serialize:
-    - name: {{ sensu.paths.checks_file }}
-    - dataset:
-        checks: {{ salt['pillar.get']('sensu:checks') }}
-    - formatter: json
-    - require:
-      - pkg: sensu
-    - watch_in:
-      - service: sensu-server
-
-{%- endif %}
-
 {%- if salt['pillar.get']('sensu:handlers') %}
 
 sensu_handlers_file:

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -60,10 +60,22 @@ sensu_handlers_file:
 
 {% set gem_list = salt['pillar.get']('sensu:server:install_gems', []) %}
 {% for gem in gem_list %}
-install_{{ gem }}:
+{% if gem is mapping %}
+{% set gem_name = gem.name %}
+{% else %}
+{% set gem_name = gem %}
+{% endif %}
+install_{{ gem_name }}:
   gem.installed:
-    - name: {{ gem }}
+    - name: {{ gem_name }}
+    {% if sensu.client.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
+    {% else %}
+    - gem_bin: None
+    {% endif %}
+    {% if gem.version is defined %}
+    - version: {{ gem.version }}
+    {% endif %}
     - rdoc: False
     - ri: False
 {% endfor %}


### PR DESCRIPTION
On this version of CentOS, it appears that by default the fqdn
isn't set. Using the id grain works.