### PR TITLE
Sensu repo fixes for Redhat

### DIFF
--- a/sensu/files/yum/osmajorrelease.template
+++ b/sensu/files/yum/osmajorrelease.template
@@ -1,0 +1,1 @@
+{{ grains['osmajorrelease'] }}

--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -8,6 +8,13 @@ python-apt:
       - pkgrepo: sensu
 {% endif %}
 
+{% if grains['os_family'] == 'RedHat' %}
+/etc/yum/vars/osmajorrelease:
+  file.managed:
+    - source: salt://sensu/files/yum/osmajorrelease.template
+    - template: jinja
+{% endif %}
+
 sensu:
   {% if repos.get('enabled') %}
   pkgrepo.managed:
@@ -28,7 +35,6 @@ sensu:
   {% endif %}
   pkg:
     - installed
-
 
 {% if grains['os_family'] != 'Windows' %}
 old sensu repository:

--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -6,7 +6,7 @@
     },
     'RedHat': {
         'enabled': True,
-        'baseurl': 'http://repositories.sensuapp.org/yum/el/{{ grains['osmajorrelease'] }}/$basearch/',
+        'baseurl': 'http://repositories.sensuapp.org/yum/el/$osmajorrelease/$basearch/',
         'gpgcheck': '0',
     },
     'Windows': {

--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -6,7 +6,7 @@
     },
     'RedHat': {
         'enabled': True,
-        'baseurl': 'http://repositories.sensuapp.org/yum/el/$releasever/$basearch/',
+        'baseurl': 'http://repositories.sensuapp.org/yum/el/{{ grains['osmajorrelease'] }}/$basearch/',
         'gpgcheck': '0',
     },
     'Windows': {


### PR DESCRIPTION
It appears that these old repo URLs are no longer valid
http://repositories.sensuapp.org/yum/el/$releasever/$basearch/
for example
http://repositories.sensuapp.org/yum/el/[6.8|7.3]/x86_64/ gives 404 whereas

http://repositories.sensuapp.org/yum/el/[6|7]/x86_64/ works

we have had to do this with some other repos in formulas so we created a custom YUM variable