### PR TITLE
Update Debian repository urls from Sensu documentation

### DIFF
--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -1,8 +1,8 @@
 {% set repos = salt['grains.filter_by']({
     'Debian': {
         'enabled': True,
-        'name': 'deb http://repositories.sensuapp.org/apt sensu main',
-        'key_url': 'http://repositories.sensuapp.org/apt/pubkey.gpg',
+        'name': 'deb https://sensu.global.ssl.fastly.net/apt {{ salt["grains.get"]("os_codename") }} main',
+        'key_url': 'https://sensu.global.ssl.fastly.net/apt/pubkey.gpg',
     },
     'RedHat': {
         'enabled': True,


### PR DESCRIPTION
The (Sensu documentation on Ubuntu/Debian installation)[https://sensuapp.org/docs/0.28/platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository] says that the repository changed in January, 2017. The latest version (0.28) is only available in the new repo. Additionally, the new repo is served over HTTPS.