### PR TITLE
Fix Debian defaults

### DIFF
--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -1,9 +1,13 @@
 {% from "sensu/repos_map.jinja" import repos with context -%}
 
 {% if grains['os_family'] == 'Debian' %}
-python-apt:
-  pkg:
-    - installed
+sensu-extra-packages:
+  pkg.installed:
+    - names:
+      - python-apt
+      {% if repos.get('enabled') and repos.get('name').startswith("https") %}
+      - apt-transport-https
+      {% endif %}
     - require_in:
       - pkgrepo: sensu
 {% endif %}

--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -1,7 +1,7 @@
 {% set repos = salt['grains.filter_by']({
     'Debian': {
         'enabled': True,
-        'name': 'deb https://sensu.global.ssl.fastly.net/apt {{ salt["grains.get"]("os_codename") }} main',
+        'name': 'deb https://sensu.global.ssl.fastly.net/apt ' ~ grains.oscodename ~ ' main',
         'key_url': 'https://sensu.global.ssl.fastly.net/apt/pubkey.gpg',
     },
     'RedHat': {


### PR DESCRIPTION
Fix rendering error in `repos_map.jinja` and add missing installation of `apt-transport-https` to deal with the new default from #37.