### PR TITLE
Fix default state rendering

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,7 @@ sensu:
     nagios_plugins: true
     redact:
       - password
+    gem_proxy: http://192.168.1.1:3128/
   rabbitmq:
     host: 10.0.0.1
     user: sensu

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -113,8 +113,8 @@ install_{{ gem_name }}:
     {% endif %}
     - rdoc: False
     - ri: False
-    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy', None) }}
-    - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
+    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy') }}
+    - source: {{ salt['pillar.get']('sensu:client:gem_source') }}
 {% endfor %}
 
 {%- if salt['pillar.get']('sensu:checks') %}

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -105,8 +105,6 @@ install_{{ gem_name }}:
     - name: {{ gem_name }}
     {% if sensu.client.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
-    {% else %}
-    - gem_bin: None
     {% endif %}
     {% if gem.version is defined %}
     - version: {{ gem.version }}

--- a/sensu/pillar_map.jinja
+++ b/sensu/pillar_map.jinja
@@ -26,6 +26,9 @@
             'user': 'sensu',
             'password': ''
         },
+        'server': {
+            'embedded_ruby': False,
+        },
         'ssl': {
             'enable': False
         },

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -78,8 +78,8 @@ install_{{ gem_name }}:
     {% endif %}
     - rdoc: False
     - ri: False
-    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy', None) }}
-    - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
+    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy') }}
+    - source: {{ salt['pillar.get']('sensu:client:gem_source') }}
 {% endfor %}
 
 sensu-server:

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -68,7 +68,7 @@ sensu_handlers_file:
 install_{{ gem_name }}:
   gem.installed:
     - name: {{ gem_name }}
-    {% if sensu.client.embedded_ruby %}
+    {% if sensu.server.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
     {% else %}
     - gem_bin: None
@@ -78,8 +78,8 @@ install_{{ gem_name }}:
     {% endif %}
     - rdoc: False
     - ri: False
-    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy') }}
-    - source: {{ salt['pillar.get']('sensu:client:gem_source') }}
+    - proxy: {{ salt['pillar.get']('sensu:server:gem_proxy') }}
+    - source: {{ salt['pillar.get']('sensu:server:gem_source') }}
 {% endfor %}
 
 sensu-server:

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -70,8 +70,6 @@ install_{{ gem_name }}:
     - name: {{ gem_name }}
     {% if sensu.server.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
-    {% else %}
-    - gem_bin: None
     {% endif %}
     {% if gem.version is defined %}
     - version: {{ gem.version }}


### PR DESCRIPTION
Current way of providing `source` and `proxy` to `gem.installed` fails like this:
```
2017-04-03 18:00:19,085 [salt.state       ][INFO    ][3242] Running state [sensu-plugins-disk-checks] at time 18:00:19.085168
2017-04-03 18:00:19,088 [salt.state       ][INFO    ][3242] Executing state gem.installed for sensu-plugins-disk-checks
2017-04-03 18:00:19,091 [salt.loaded.int.module.cmdmod][INFO    ][3242] Executing command ['/opt/sensu/embedded/bin/gem', 'list', 'sensu-plugins-disk-checks'] in directory '/root'
2017-04-03 18:00:21,220 [salt.loaded.int.module.cmdmod][INFO    ][3242] Executing command ['/opt/sensu/embedded/bin/gem', 'install', 'sensu-plugins-disk-checks', '--no-rdoc', '--no-ri', '-p', 'None', '--source', 'None'] in directory '/root'
2017-04-03 18:00:23,573 [salt.loaded.int.module.cmdmod][ERROR   ][3242] Command '['/opt/sensu/embedded/bin/gem', 'install', 'sensu-plugins-disk-checks', '--no-rdoc', '--no-ri', '-p', 'None', '--source', 'None']' failed with return code: 1
2017-04-03 18:00:23,576 [salt.loaded.int.module.cmdmod][ERROR   ][3242] stderr: ERROR:  While executing gem ... (OptionParser::InvalidArgument)
    invalid argument: -p None
2017-04-03 18:00:23,578 [salt.loaded.int.module.cmdmod][ERROR   ][3242] retcode: 1
2017-04-03 18:00:23,582 [salt.state       ][ERROR   ][3242] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1735, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1653, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/states/gem.py", line 108, in installed
    source=source):
  File "/usr/lib/python2.7/dist-packages/salt/modules/gem.py", line 138, in install
    runas=runas)
  File "/usr/lib/python2.7/dist-packages/salt/modules/gem.py", line 66, in _gem
    raise CommandExecutionError(ret['stderr'])
CommandExecutionError: ERROR:  While executing gem ... (OptionParser::InvalidArgument)
    invalid argument: -p None

2017-04-03 18:00:23,588 [salt.state       ][INFO    ][3242] Completed state [sensu-plugins-disk-checks] at time 18:00:23.587710 duration_in_ms=4502.541
```

This is due to providing None as a default value to pillar.get which is rendered in state as 'None' which is not equivalent to the None value that YAML understands.