### PR TITLE
Add server side checks

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -23,7 +23,6 @@ sensu_enable_windows_service:
 {% endif %}
 
 {%- if salt['pillar.get']('sensu:standalone_checks') %}
-
 sensu_standalone_checks_file:
   file.serialize:
     - name: {{ sensu.paths.standalone_checks_file }}
@@ -34,7 +33,10 @@ sensu_standalone_checks_file:
       - pkg: sensu
     - watch_in:
       - service: sensu-client
-
+{%- else %}
+sensu_standalone_checks_file:
+  file.absent:
+    - name: {{ sensu.paths.standalone_checks_file }}
 {%- endif %}
 
 /etc/sensu/conf.d/client.json:

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -22,6 +22,21 @@ sensu_enable_windows_service:
     - unless: 'sc query sensu-client'
 {% endif %}
 
+{%- if salt['pillar.get']('sensu:checks') %}
+
+sensu_checks_file:
+  file.serialize:
+    - name: {{ sensu.paths.checks_file }}
+    - dataset:
+        checks: {{ salt['pillar.get']('sensu:checks') }}
+    - formatter: json
+    - require:
+      - pkg: sensu
+    - watch_in:
+      - service: sensu-client
+
+{%- endif %}
+
 /etc/sensu/conf.d/client.json:
   file.serialize:
     - formatter: json
@@ -117,17 +132,3 @@ install_{{ gem_name }}:
     - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
 {% endfor %}
 
-{%- if salt['pillar.get']('sensu:checks') %}
-
-sensu_checks_file:
-  file.serialize:
-    - name: {{ sensu.paths.checks_file }}
-    - dataset:
-        checks: {{ salt['pillar.get']('sensu:checks') }}
-    - formatter: json
-    - require:
-      - pkg: sensu
-    - watch_in:
-      - service: sensu-client
-
-{%- endif %}

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -77,15 +77,6 @@ sensu_checks_file:
     - watch_in:
       - service: sensu-client
 
-sensu-client:
-  service.running:
-    - enable: True
-    - require:
-      - file: /etc/sensu/conf.d/client.json
-      - file: /etc/sensu/conf.d/rabbitmq.json
-    - watch:
-      - file: /etc/sensu/conf.d/*
-
 {% if grains['os_family'] != 'Windows' %}
 /etc/default/sensu:
   file.replace:
@@ -132,3 +123,11 @@ install_{{ gem_name }}:
     - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
 {% endfor %}
 
+sensu-client:
+  service.running:
+    - enable: True
+    - require:
+      - file: /etc/sensu/conf.d/client.json
+      - file: /etc/sensu/conf.d/rabbitmq.json
+    - watch:
+      - file: /etc/sensu/conf.d/*

--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -22,13 +22,13 @@ sensu_enable_windows_service:
     - unless: 'sc query sensu-client'
 {% endif %}
 
-{%- if salt['pillar.get']('sensu:checks') %}
+{%- if salt['pillar.get']('sensu:standalone_checks') %}
 
-sensu_checks_file:
+sensu_standalone_checks_file:
   file.serialize:
-    - name: {{ sensu.paths.checks_file }}
+    - name: {{ sensu.paths.standalone_checks_file }}
     - dataset:
-        checks: {{ salt['pillar.get']('sensu:checks') }}
+        checks: {{ salt['pillar.get']('sensu:standalone_checks') }}
     - formatter: json
     - require:
       - pkg: sensu

--- a/sensu/pillar_map.jinja
+++ b/sensu/pillar_map.jinja
@@ -62,13 +62,14 @@
             }
         ],
         'paths': {
-            'plugins'       : 'sensu/files/plugins',
-            'conf_d'        : 'sensu/files/conf.d',
-            'extensions'    : 'sensu/files/extensions',
-            'mutators'      : 'sensu/files/mutators',
-            'handlers'      : 'sensu/files/handlers',
-            'checks_file'   : '/etc/sensu/conf.d/checks.json',
-            'handlers_file' : '/etc/sensu/conf.d/handlers.json',
+            'plugins'                : 'sensu/files/plugins',
+            'conf_d'                 : 'sensu/files/conf.d',
+            'extensions'             : 'sensu/files/extensions',
+            'mutators'               : 'sensu/files/mutators',
+            'handlers'               : 'sensu/files/handlers',
+            'checks_file'            : '/etc/sensu/conf.d/checks.json',
+            'standalone_checks_file' : '/etc/sensu/conf.d/standalone_checks.json',
+            'handlers_file'          : '/etc/sensu/conf.d/handlers.json',
         },
     },
 }, merge=salt['pillar.get']('sensu'), default='default') %}

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -17,7 +17,7 @@ include:
 
 {%- if salt['pillar.get']('sensu:checks') %}
 
-sensu_checks_file:
+sensu_subscription_checks_file:
   file.serialize:
     - name: {{ sensu.paths.checks_file }}
     - dataset:

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -16,7 +16,6 @@ include:
       - service: sensu-server
 
 {%- if salt['pillar.get']('sensu:checks') %}
-
 sensu_subscription_checks_file:
   file.serialize:
     - name: {{ sensu.paths.checks_file }}
@@ -27,7 +26,10 @@ sensu_subscription_checks_file:
       - pkg: sensu
     - watch_in:
       - service: sensu-server
-
+{%- else %}
+sensu_subscription_checks_file:
+  file.absent:
+    - name: {{ sensu.paths.checks_file }}
 {%- endif %}
 
 {%- if salt['pillar.get']('sensu:handlers') %}

--- a/sensu/server.sls
+++ b/sensu/server.sls
@@ -15,13 +15,28 @@ include:
     - watch_in:
       - service: sensu-server
 
+{%- if salt['pillar.get']('sensu:checks') %}
+
+sensu_checks_file:
+  file.serialize:
+    - name: {{ sensu.paths.checks_file }}
+    - dataset:
+        checks: {{ salt['pillar.get']('sensu:checks') }}
+    - formatter: json
+    - require:
+      - pkg: sensu
+    - watch_in:
+      - service: sensu-server
+
+{%- endif %}
+
 {%- if salt['pillar.get']('sensu:handlers') %}
 
 sensu_handlers_file:
   file.serialize:
     - name: {{ sensu.paths.handlers_file }}
     - dataset_pillar: sensu:handlers
-    - formatter: JSON
+    - formatter: json
     - require:
       - pkg: sensu
     - watch_in:


### PR DESCRIPTION
According to [Sensu documentation](https://sensuapp.org/docs/0.28/overview/architecture.html#check-execution-scheduler), sensu-server is responsible for distributing checks, while clients may have their own local checks. Make sure the formula can deal with it.

I am in the process of splitting a mono server installation and there is no guarantee that a client will run on the same machine as the server so I need this to work as documented in upstream documentation. I also found some other oddities of the same kind but this is my main problem right now.