### PR TITLE
Do not set gem options to 'None'

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -105,16 +105,18 @@ install_{{ gem_name }}:
     - name: {{ gem_name }}
     {% if sensu.client.embedded_ruby %}
     - gem_bin: /opt/sensu/embedded/bin/gem
-    {% else %}
-    - gem_bin: None
     {% endif %}
     {% if gem.version is defined %}
     - version: {{ gem.version }}
     {% endif %}
     - rdoc: False
     - ri: False
-    - proxy: {{ salt['pillar.get']('sensu:client:gem_proxy', None) }}
-    - source: {{ salt['pillar.get']('sensu:client:gem_source', None) }}
+    {% if sensu.client.gem_proxy is defined %}
+    - proxy: {{ sensu.client.gem_proxy }}
+    {% endif %}
+    {% if sensu.client.gem_source is defined %}
+    - source: {{ sensu.client.gem_source }}
+    {% endif %}
 {% endfor %}
 
 {%- if salt['pillar.get']('sensu:checks') %}


### PR DESCRIPTION
Setting map values in yaml to None leads to it setting the value to the string 'None' instead of the actual None.