### PR TITLE
Add override_attributes to client.json

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -46,6 +46,11 @@ sensu_enable_windows_service:
           {% if sensu.client.get("redact") %}
           redact: {{ sensu.client.redact }}
           {% endif %}
+          {% if sensu.client.get("override_attributes") %}
+          {% for attribute, values in sensu.client.override_attributes.items() %}
+          {{ attribute }}: {{ values|json }}
+          {% endfor %}
+          {% endif %}
     - require:
       - pkg: sensu
 


### PR DESCRIPTION
Add the possibility to add override attributes to the client.json to use [token substitution](https://sensuapp.org/docs/latest/reference/checks.html#check-token-substitution)

Usable with:
```yaml
sensu:
  client:
    override_attributes:
      memory:
        warn: 90
        crit: 95
```