### PR TITLE
manage sensu package version if repo enabled

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,7 @@ sensu:
     repos:
       name: deb http://repositories.sensuapp.org/apt sensu main
       key_url: http://repositories.sensuapp.org/apt/pubkey.gpg
+      pkg_version: 1.2.0-1
   server:
     install_gems:
       - mail

--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -36,8 +36,13 @@ sensu:
     {% endif %}
     - require_in:
       - pkg: sensu
+  {%- if repos.get('pkg_version') %}
   pkg.installed:
     - version: {{ repos.get('pkg_version') }}
+  {%- else %}
+  pkg:
+    - latest
+  {%- endif %}
   {% endif %}
   {% else %}
   pkg:

--- a/sensu/init.sls
+++ b/sensu/init.sls
@@ -36,9 +36,13 @@ sensu:
     {% endif %}
     - require_in:
       - pkg: sensu
+  pkg.installed:
+    - version: {{ repos.get('pkg_version') }}
   {% endif %}
+  {% else %}
   pkg:
     - installed
+  {% endif %}
 
 {% if grains['os_family'] != 'Windows' %}
 old sensu repository:

--- a/sensu/repos_map.jinja
+++ b/sensu/repos_map.jinja
@@ -3,11 +3,13 @@
         'enabled': True,
         'name': 'deb https://sensu.global.ssl.fastly.net/apt ' ~ grains.oscodename ~ ' main',
         'key_url': 'https://sensu.global.ssl.fastly.net/apt/pubkey.gpg',
+        'pkg_version': 'latest',
     },
     'RedHat': {
         'enabled': True,
         'baseurl': 'https://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/',
         'gpgcheck': '0',
+        'pkg_version': 'latest',
     },
     'Windows': {
         'enabled': False,


### PR DESCRIPTION
Current sensu formula will install the latest available package if absent, but will keep current package if already installed.

This PR introduces a version parameter when the package comes from a repository, allowing to pin the package version. Default value (coming from jinja template) is set to 'latest'.